### PR TITLE
Use Docker-in-Docker on Kubernetes

### DIFF
--- a/k8s-services.yml
+++ b/k8s-services.yml
@@ -15,21 +15,3 @@ spec:
   - protocol: TCP
     port: 8000
     nodePort: 30080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: reproserver-registry-prod
-  labels:
-    app: reproserver
-    tier: prod
-spec:
-  selector:
-    app: reproserver
-    repro-pod: registry
-    tier: prod
-  type: NodePort
-  ports:
-  - protocol: TCP
-    port: 5000
-    nodePort: 30500


### PR DESCRIPTION
Run a Docker-in-Docker container in the builder and runner pods. Use that for the experiment instead of the cluster one.

This has two advantages:
* We can use proper Kubernetes service names instead of a global NodePort that the Docker daemon will see
* We can enable userns-remap without interfering with Kubernetes

Fixes #4