### PR TITLE
Use short IDs (like YouTube or OSF) for experiments

### DIFF
--- a/common/common/database.py
+++ b/common/common/database.py
@@ -153,7 +153,9 @@ class Run(Base):
                                                 ondelete='CASCADE'))
     experiment = relationship('Experiment', uselist=False,
                               back_populates='runs')
-    experiment_filename = Column(String, nullable=False)
+    upload_id = Column(Integer, ForeignKey('uploads.id',
+                                           ondelete='RESTRICT'))
+    upload = relationship('Upload', uselist=False)
     submitted = Column(DateTime, nullable=False,
                        server_default=functions.now())
     started = Column(DateTime, nullable=True)

--- a/common/common/database.py
+++ b/common/common/database.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.sql import functions
 from sqlalchemy.types import Boolean, DateTime, Enum, Integer, String
 
-from common.shortid import ShortIDs
+from common.shortid import MultiShortIDs
 
 
 Base = declarative_base()
@@ -76,8 +76,8 @@ class Upload(Base):
                        server_default=functions.now())
 
     @property
-    def experiment_code(self):
-        return short_ids.encode(self.id)
+    def short_id(self):
+        return short_ids.encode('upload', self.id)
 
     def __repr__(self):
         return ("<Upload id=%d, experiment_hash=%r, filename=%r, "
@@ -166,6 +166,10 @@ class Run(Base):
 
     log = relationship('RunLogLine', back_populates='run')
     output_files = relationship('OutputFile', back_populates='run')
+
+    @property
+    def short_id(self):
+        return short_ids.encode('run', self.id)
 
     def get_log(self, from_line=0):
         return [log.line for log in self.log[from_line:]]
@@ -297,7 +301,7 @@ def connect(url=None):
     """Connect to the database using an environment variable.
     """
     global short_ids
-    short_ids = ShortIDs(os.environ['SHORTIDS_SALT'])
+    short_ids = MultiShortIDs(os.environ['SHORTIDS_SALT'])
 
     logging.info("Connecting to SQL database")
     if url is None:

--- a/common/common/database.py
+++ b/common/common/database.py
@@ -1,4 +1,3 @@
-import base64
 import enum
 import logging
 import os
@@ -7,6 +6,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.sql import functions
 from sqlalchemy.types import Boolean, DateTime, Enum, Integer, String
+
+from common.shortid import ShortIDs
 
 
 Base = declarative_base()
@@ -76,9 +77,7 @@ class Upload(Base):
 
     @property
     def experiment_code(self):
-        return base64.urlsafe_b64encode(self.experiment_hash +
-                                        '|' +
-                                        self.filename)
+        return short_ids.encode(self.id)
 
     def __repr__(self):
         return ("<Upload id=%d, experiment_hash=%r, filename=%r, "
@@ -295,6 +294,9 @@ def purge(url=None):
 def connect(url=None):
     """Connect to the database using an environment variable.
     """
+    global short_ids
+    short_ids = ShortIDs(os.environ['SHORTIDS_SALT'])
+
     logging.info("Connecting to SQL database")
     if url is None:
         url = 'postgresql://{user}:{password}@{host}/{database}'.format(

--- a/common/common/shortid.py
+++ b/common/common/shortid.py
@@ -57,3 +57,30 @@ class ShortIDs(object):
         """Decode a random-looking short ID into the original number.
         """
         return _decode(shortid, self.cmap)
+
+
+class MultiShortIDs(object):
+    """Generates multiple sequences of short IDs.
+
+    You probably don't want IDs for different things to follow the same
+    sequence. Use this class to use multiple sequences, without having to keep
+    multiple generators around (or provide multiple salts).
+    """
+    def __init__(self, salt, min_chars=5):
+        self.salt = salt
+        self.min_chars = min_chars
+        self.shortids = {}
+
+    def encode(self, key, nb):
+        try:
+            s = self.shortids[key]
+        except KeyError:
+            s = self.shortids[key] = ShortIDs(key + self.salt)
+        return s.encode(nb, self.min_chars)
+
+    def decode(self, key, shortid):
+        try:
+            s = self.shortids[key]
+        except KeyError:
+            s = self.shortids[key] = ShortIDs(key + self.salt)
+        return s.decode(shortid)

--- a/common/common/shortid.py
+++ b/common/common/shortid.py
@@ -1,0 +1,59 @@
+__all__ = ['ShortIDs']
+
+
+CHARS = u'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz-_'
+
+
+def _encode(nb, min_chars, chars):
+    nb_chars = len(chars)
+    shortid = []
+    idx = 0
+    i = 0
+    while nb or i < min_chars:
+        idx = (idx + nb) % nb_chars
+        shortid.append(chars[idx])
+        idx += 1
+        nb = nb // nb_chars
+        i += 1
+    return u''.join(reversed(shortid))
+
+
+def _decode(shortid, cmap):
+    nb_chars = len(cmap)
+    nb = 0
+    e = 1
+    prev_idx = 0
+    for c in reversed(shortid):
+        idx = cmap[c]
+        d = (idx - prev_idx) % nb_chars
+        nb += d * e
+        prev_idx = idx + 1
+        e *= nb_chars
+    return nb
+
+
+class ShortIDs(object):
+    """Encodes IDs as short strings.
+
+    This turns a number into a short random-looking string like 'dxT2_x'.
+    """
+    def __init__(self, salt):
+        chars = list(CHARS)
+        l = len(salt)
+        nb_chars = len(chars)
+        for i in range(nb_chars):
+            s = ord(salt[i % l])
+            j = i + s % (nb_chars - i)
+            chars[i], chars[j] = chars[j], chars[i]
+        self.chars = u''.join(chars)
+        self.cmap = dict((c, i) for i, c in enumerate(self.chars))
+
+    def encode(self, nb, min_chars=5):
+        """Encode a number into a random-looking short ID.
+        """
+        return _encode(nb, min_chars, self.chars)
+
+    def decode(self, shortid):
+        """Decode a random-looking short ID into the original number.
+        """
+        return _decode(shortid, self.cmap)

--- a/common/common/shortid.py
+++ b/common/common/shortid.py
@@ -1,7 +1,7 @@
 __all__ = ['ShortIDs']
 
 
-CHARS = u'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz-_'
+CHARS = u'023456789abcdefghijkmnopqrstuvwxyz'
 
 
 def _encode(nb, min_chars, chars):

--- a/dodo.py
+++ b/dodo.py
@@ -161,6 +161,7 @@ def run(name, dct):
 ADMIN_USER = 'reproserver'
 ADMIN_PASSWORD = 'hackmehackme'
 common_env = {
+    'SHORTIDS_SALT': 'thisisarandomstring',
     'AMQP_USER': ADMIN_USER,
     'AMQP_PASSWORD': ADMIN_PASSWORD,
     'AMQP_HOST': '%srabbitmq' % PREFIX,

--- a/k8s.tpl.yml
+++ b/k8s.tpl.yml
@@ -20,6 +20,11 @@ spec:
       - name: web
         image: {{ image_registry }}reproserver-web{{ tag }}
         env:
+        - name: SHORTIDS_SALT
+          valueFrom:
+            secretKeyRef:
+              name: reproserver-secret-{{ tier }}
+              key: salt
         - name: AMQP_USER
           valueFrom:
             secretKeyRef:
@@ -97,6 +102,11 @@ spec:
           value: "reproserver-registry-{{ tier }}:5000"
         - name: DOCKER_HOST
           value: 127.0.0.1:2375
+        - name: SHORTIDS_SALT
+          valueFrom:
+            secretKeyRef:
+              name: reproserver-secret-{{ tier }}
+              key: salt
         - name: AMQP_USER
           valueFrom:
             secretKeyRef:
@@ -170,6 +180,11 @@ spec:
           value: "reproserver-registry-{{ tier }}:5000"
         - name: DOCKER_HOST
           value: 127.0.0.1:2375
+        - name: SHORTIDS_SALT
+          valueFrom:
+            secretKeyRef:
+              name: reproserver-secret-{{ tier }}
+              key: salt
         - name: AMQP_USER
           valueFrom:
             secretKeyRef:
@@ -378,6 +393,11 @@ spec:
       - name: reproserver-init-{{ tier }}
         image: {{ image_registry }}reproserver-init{{ tag }}
         env:
+        - name: SHORTIDS_SALT
+          valueFrom:
+            secretKeyRef:
+              name: reproserver-secret-{{ tier }}
+              key: salt
         - name: S3_KEY
           valueFrom:
             secretKeyRef:

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -231,7 +231,7 @@ def run(experiment_code):
     # New run entry
     try:
         run = database.Run(experiment_hash=experiment.hash,
-                           experiment_filename=filename)
+                           upload_id=upload_id)
         session.add(run)
 
         # Get list of parameters
@@ -336,9 +336,7 @@ def results(run_id):
                         'log': run.get_log(log_from)})
     # HTML view, return the page
     else:
-        experiment_code = base64.urlsafe_b64encode(run.experiment_hash +
-                                                   '|' +
-                                                   run.experiment_filename)
+        experiment_code = short_ids.encode(run.upload_id)
         return render_template('results.html', run=run,
                                log=run.get_log(0),
                                started=bool(run.started),

--- a/web/web/templates/base.html
+++ b/web/web/templates/base.html
@@ -31,7 +31,7 @@
             <ul class="nav navbar-nav">
               <li><a href="{{ url_for('index') }}">Unpack</a></li>
 {% if experiment_code %}
-              <li><a href="{{ url_for('reproduce', experiment_code=experiment_code) }}">Reproduce</a></li>
+              <li><a href="{{ url_for('reproduce', upload_short_id=experiment_code) }}">Reproduce</a></li>
 {% endif %}
 {% if run_id %}
               <li><a href="">View run</a></li>

--- a/web/web/templates/data.html
+++ b/web/web/templates/data.html
@@ -13,7 +13,7 @@
   {% for upload in experiment.uploads %}
 
   <p>Uploaded by {{ upload.submitted_ip }} at {{ upload.timestamp }}
-  as <a href="{{ url_for('reproduce', experiment_code=upload.experiment_code) }}">{{ upload.filename }}</a></p>
+  as <a href="{{ url_for('reproduce', upload_short_id=upload.short_id) }}">{{ upload.filename }}</a></p>
 
   {% endfor %}
 

--- a/web/web/templates/data.html
+++ b/web/web/templates/data.html
@@ -32,7 +32,7 @@
 
   {% for run in experiment.runs %}
 
-  <h2>Run {{ run.id }} submitted at {{ run.submitted }}</h2>
+  <h2><a href="{{ url_for('results', run_short_id=run.short_id) }}">Run {{ run.id }}</a> submitted at {{ run.submitted }}</h2>
 
   <p>Started: {{ run.started }}<br/>
   Done: {{ run.done }}</p>

--- a/web/web/templates/index.html
+++ b/web/web/templates/index.html
@@ -27,7 +27,7 @@ You can also choose one of the examples below.</p>
 
   {% for example in examples %}
 
-<p><a href="{{ url_for('reproduce', experiment_code=example.upload.experiment_code) }}">{{ example.upload.filename }}</a>: {{ example.description }}</p>
+<p><a href="{{ url_for('reproduce', upload_short_id=example.upload.short_id) }}">{{ example.upload.filename }}</a>: {{ example.description }}</p>
 
   {% endfor %}
 

--- a/web/web/templates/results.html
+++ b/web/web/templates/results.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<h1>Package <a href="{{ url_for('reproduce', experiment_code=experiment_code) }}">{{ run.experiment_filename }}</a>, run #{{ run.id }}</h1>
+<h1>Package <a href="{{ url_for('reproduce', experiment_code=experiment_code) }}">{{ run.upload.filename }}</a>, run #{{ run.id }}</h1>
 
 <div class="panel panel-default" id="panel1">
   <div class="panel-heading">

--- a/web/web/templates/results.html
+++ b/web/web/templates/results.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<h1>Package <a href="{{ url_for('reproduce', experiment_code=experiment_code) }}">{{ run.upload.filename }}</a>, run #{{ run.id }}</h1>
+<h1>Package <a href="{{ url_for('reproduce', upload_short_id=experiment_code) }}">{{ run.upload.filename }}</a>, run #{{ run.id }}</h1>
 
 <div class="panel panel-default" id="panel1">
   <div class="panel-heading">

--- a/web/web/templates/setup.html
+++ b/web/web/templates/setup.html
@@ -35,7 +35,7 @@
 
 <h2>Run the experiment</h2>
 
-<form method="POST" action="{{ url_for('run', experiment_code=experiment_code) }}" enctype="multipart/form-data">
+<form method="POST" action="{{ url_for('run', upload_short_id=experiment_code) }}" enctype="multipart/form-data">
   <h3>Parameters</h3>
 
     {% if params %}


### PR DESCRIPTION
Fixes #8

The ID actually identifies an upload, not an experiment. This is because experiments have no name, and we want to display a filename.

There might be multiple IDs for the same experiment (even with the same name), as each time it is re-uploaded a new ID is presented.

This makes those IDs non-unique across DB resets.