### PR TITLE
Serve outputs directly from S3

### DIFF
--- a/aws_policy.json
+++ b/aws_policy.json
@@ -1,0 +1,51 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowListBuckets",
+      "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::*"
+      ]
+    },
+    {
+      "Sid": "AllowGetPutExperiments",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::reproserver-prod-experiments/*"
+      ]
+    },
+    {
+      "Sid": "AllowGetPutInputs",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::reproserver-prod-inputs/*"
+      ]
+    },
+    {
+      "Sid": "AllowGetPutOutputs",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::reproserver-prod-outputs/*"
+      ]
+    }
+  ]
+}

--- a/builder/builder/main.py
+++ b/builder/builder/main.py
@@ -87,8 +87,7 @@ def build(channel, method, properties, body):
         logging.info("Downloading file...")
         local_path = os.path.join(directory, 'experiment.rpz')
         build_dir = os.path.join(directory, 'build_dir')
-        object_store.Bucket('experiments').download_file(experiment.hash,
-                                                         local_path)
+        object_store.download_file('experiments', experiment.hash, local_path)
         logging.info("Got file, %d bytes", os.stat(local_path).st_size)
 
         # Get metadata

--- a/builder/builder/main.py
+++ b/builder/builder/main.py
@@ -10,7 +10,7 @@ import tempfile
 
 
 SQLSession = None
-s3 = None
+object_store = None
 
 
 # IP as understood by Docker daemon, not this container
@@ -87,7 +87,8 @@ def build(channel, method, properties, body):
         logging.info("Downloading file...")
         local_path = os.path.join(directory, 'experiment.rpz')
         build_dir = os.path.join(directory, 'build_dir')
-        s3.Bucket('experiments').download_file(experiment.hash, local_path)
+        object_store.Bucket('experiments').download_file(experiment.hash,
+                                                         local_path)
         logging.info("Got file, %d bytes", os.stat(local_path).st_size)
 
         # Get metadata
@@ -186,8 +187,8 @@ def main():
     tasks = TaskQueues()
 
     # Object storage
-    global s3
-    s3 = get_object_store()
+    global object_store
+    object_store = get_object_store()
 
     # Wait for tasks
     logging.info("Ready, listening for requests")

--- a/common/common/objectstore.py
+++ b/common/common/objectstore.py
@@ -1,11 +1,15 @@
 import boto3
+from botocore.client import Config
 import logging
 import os
 
 
-def get_object_store():
+def get_object_store(endpoint_url=None):
     logging.info("Logging in to S3")
-    s3_url = os.environ.get('S3_URL') or None
-    return boto3.resource('s3', endpoint_url=s3_url,
+    if endpoint_url is None:
+        endpoint_url = os.environ.get('S3_URL') or None
+    return boto3.resource('s3', endpoint_url=endpoint_url,
                           aws_access_key_id=os.environ['S3_KEY'],
-                          aws_secret_access_key=os.environ['S3_SECRET'])
+                          aws_secret_access_key=os.environ['S3_SECRET'],
+                          region_name='us-east-1',
+                          config=Config(signature_version='s3v4'))

--- a/common/common/objectstore.py
+++ b/common/common/objectstore.py
@@ -8,8 +8,53 @@ def get_object_store(endpoint_url=None):
     logging.info("Logging in to S3")
     if endpoint_url is None:
         endpoint_url = os.environ.get('S3_URL') or None
-    return boto3.resource('s3', endpoint_url=endpoint_url,
-                          aws_access_key_id=os.environ['S3_KEY'],
-                          aws_secret_access_key=os.environ['S3_SECRET'],
-                          region_name='us-east-1',
-                          config=Config(signature_version='s3v4'))
+    bucket_prefix = os.environ['S3_BUCKET_PREFIX']
+    return ObjectStore(endpoint_url, bucket_prefix)
+
+
+class ObjectStore(object):
+    def __init__(self, endpoint_url, bucket_prefix):
+        self.s3 = boto3.resource('s3', endpoint_url=endpoint_url,
+            aws_access_key_id=os.environ['S3_KEY'],
+            aws_secret_access_key=os.environ['S3_SECRET'],
+            region_name='us-east-1',
+            config=Config(signature_version='s3v4'))
+        self.bucket_prefix = bucket_prefix
+
+    def bucket_name(self, name):
+        if name not in ('experiments', 'inputs', 'outputs'):
+            raise ValueError("Invalid bucket name %s" % name)
+
+        name = '%s-%s-%s' % ('reproserver', self.bucket_prefix, name)
+        return name
+
+    def bucket(self, name):
+        return self.s3.Bucket(self.bucket_name(name))
+
+    def download_file(self, bucket, objectname, filename):
+        self.bucket(bucket).download_file(objectname, filename)
+
+    def upload_fileobj(self, bucket, objectname, fileobj):
+        self.s3.Object(self.bucket_name(bucket), objectname).put(Body=fileobj)
+
+    def create_buckets(self):
+        buckets = set(bucket.name for bucket in self.s3.buckets.all())
+        missing = []
+        for name in ('experiments', 'inputs', 'outputs'):
+            name = self.bucket_name(name)
+            if name not in buckets:
+                missing.append(name)
+
+        if missing:
+            logging.info("The buckets don't seem to exist; creating %s",
+                         ", ".join(missing))
+            for name in missing:
+                self.s3.create_bucket(Bucket=name)
+
+    def presigned_serve_url(self, bucket, objectname, filename):
+        return self.s3.meta.client.generate_presigned_url(
+            ClientMethod='get_object',
+            Params={'Bucket': self.bucket_name(bucket),
+                    'Key': objectname,
+                    'ResponseContentDisposition': 'inline; filename=%s' %
+                                                  filename})

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -17,6 +17,8 @@ prod:
   # Note that if you are proxying this under a subdirectory, request signatures
   # will fail
   s3_client_url: "https://server.reprozip.org/files"
+  # Prefix for the name of the S3 buckets
+  s3_bucket_prefix: "prod"
 
 # Development environment, no persistence
 dev:
@@ -28,5 +30,6 @@ dev:
   liveness_probe_period_seconds: 60
   # URL through which the users can access S3
   s3_client_url: "https://devfiles.server.reprozip.org"
+  s3_bucket_prefix: ""
   # Don't run the init job
   init_job: false

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -12,6 +12,8 @@ prod:
   tag: 0.4
   # Period for the Kubernetes liveness checks
   liveness_probe_period_seconds: 60
+  # URL through which the users can access S3
+  s3_client_url: "https://server.reprozip.org/files/"
 
 # Development environment, no persistence
 dev:
@@ -21,5 +23,7 @@ dev:
   postgres_volume: false
   # Period for the Kubernetes liveness checks
   liveness_probe_period_seconds: 60
+  # URL through which the users can access S3
+  s3_client_url: "https://server.reprozip.org/dev/files/"
   # Don't run the init job
   init_job: false

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -12,8 +12,11 @@ prod:
   tag: 0.4
   # Period for the Kubernetes liveness checks
   liveness_probe_period_seconds: 60
-  # URL through which the users can access S3
-  s3_client_url: "https://server.reprozip.org/files/"
+  # URL through which the users can access S3 (useful if running Minio and we
+  # access it internally using a different URL than what the users see)
+  # Note that if you are proxying this under a subdirectory, request signatures
+  # will fail
+  s3_client_url: "https://server.reprozip.org/files"
 
 # Development environment, no persistence
 dev:
@@ -24,6 +27,6 @@ dev:
   # Period for the Kubernetes liveness checks
   liveness_probe_period_seconds: 60
   # URL through which the users can access S3
-  s3_client_url: "https://server.reprozip.org/dev/files/"
+  s3_client_url: "https://devfiles.server.reprozip.org"
   # Don't run the init job
   init_job: false

--- a/dodo.py
+++ b/dodo.py
@@ -169,6 +169,7 @@ common_env = {
     'S3_KEY': ADMIN_USER,
     'S3_SECRET': ADMIN_PASSWORD,
     'S3_URL': 'http://%sminio:9000' % PREFIX,
+    'S3_CLIENT_URL': 'http://localhost:9000',
     'POSTGRES_USER': ADMIN_USER,
     'POSTGRES_PASSWORD': ADMIN_PASSWORD,
     'POSTGRES_HOST': '%spostgres' % PREFIX,
@@ -325,6 +326,7 @@ def make_k8s_def():
             tier=config['tier'])
     else:
         context['s3_url'] = ''
+    context['s3_client_url'] = config.pop('s3_client_url', '')
 
     if 'tag' not in config:
         return TaskFailed("You must set a tag explicitly, either in "

--- a/dodo.py
+++ b/dodo.py
@@ -169,6 +169,7 @@ common_env = {
     'S3_KEY': ADMIN_USER,
     'S3_SECRET': ADMIN_PASSWORD,
     'S3_URL': 'http://%sminio:9000' % PREFIX,
+    'S3_BUCKET_PREFIX': PREFIX,
     'S3_CLIENT_URL': 'http://localhost:9000',
     'POSTGRES_USER': ADMIN_USER,
     'POSTGRES_PASSWORD': ADMIN_PASSWORD,
@@ -326,6 +327,7 @@ def make_k8s_def():
             tier=config['tier'])
     else:
         context['s3_url'] = ''
+    context['s3_bucket_prefix'] = config.pop('s3_bucket_prefix')
     context['s3_client_url'] = config.pop('s3_client_url', '')
 
     if 'tag' not in config:

--- a/init/init.py
+++ b/init/init.py
@@ -45,15 +45,15 @@ def main():
         Base.metadata.create_all(bind=engine)
 
     # Object storage
-    s3 = get_object_store()
+    object_store = get_object_store()
 
-    it = iter(s3.buckets.all())
+    it = iter(object_store.buckets.all())
     try:
         next(it)
     except StopIteration:
         logging.info("The buckets don't seem to exist; creating")
         for name in ['experiments', 'inputs', 'outputs']:
-            s3.create_bucket(Bucket=name)
+            object_store.create_bucket(Bucket=name)
 
     # Download the examples and add them
     examples = [
@@ -97,7 +97,8 @@ def main():
                     downloaded_file.seek(0, 0)
 
                     # Insert it on S3
-                    s3.Object('experiments', filehash).put(Body=downloaded_file)
+                    object_store.Object('experiments', filehash).put(
+                        Body=downloaded_file)
                     logging.info("Inserted file in storage")
 
                     # Insert it in database

--- a/init/init.py
+++ b/init/init.py
@@ -47,13 +47,7 @@ def main():
     # Object storage
     object_store = get_object_store()
 
-    it = iter(object_store.buckets.all())
-    try:
-        next(it)
-    except StopIteration:
-        logging.info("The buckets don't seem to exist; creating")
-        for name in ['experiments', 'inputs', 'outputs']:
-            object_store.create_bucket(Bucket=name)
+    object_store.create_buckets()
 
     # Download the examples and add them
     examples = [
@@ -97,8 +91,8 @@ def main():
                     downloaded_file.seek(0, 0)
 
                     # Insert it on S3
-                    object_store.Object('experiments', filehash).put(
-                        Body=downloaded_file)
+                    object_store.upload_fileobj('experiments', filehash,
+                                                downloaded_file)
                     logging.info("Inserted file in storage")
 
                     # Insert it in database

--- a/k8s-services.yml
+++ b/k8s-services.yml
@@ -15,3 +15,21 @@ spec:
   - protocol: TCP
     port: 8000
     nodePort: 30080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reproserver-s3-prod
+  labels:
+    app: reproserver
+    tier: prod
+spec:
+  selector:
+    app: reproserver
+    repro-pod: minio
+    tier: prod
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 9000
+    nodePort: 30090

--- a/k8s.tpl.yml
+++ b/k8s.tpl.yml
@@ -44,6 +44,8 @@ spec:
               key: {% if use_minio %}password{% else %}s3_secret{% endif %}
         - name: S3_URL
           value: "{{ s3_url }}"
+        - name: S3_BUCKET_PREFIX
+          value: "{{ s3_bucket_prefix }}"
         - name: S3_CLIENT_URL
           value: "{{ s3_client_url }}"
         - name: POSTGRES_USER
@@ -123,6 +125,8 @@ spec:
               key: {% if use_minio %}password{% else %}s3_secret{% endif %}
         - name: S3_URL
           value: "{{ s3_url }}"
+        - name: S3_BUCKET_PREFIX
+          value: "{{ s3_bucket_prefix }}"
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
@@ -196,6 +200,8 @@ spec:
               key: {% if use_minio %}password{% else %}s3_secret{% endif %}
         - name: S3_URL
           value: "{{ s3_url }}"
+        - name: S3_BUCKET_PREFIX
+          value: "{{ s3_bucket_prefix }}"
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
@@ -392,6 +398,8 @@ spec:
               key: {% if use_minio %}password{% else %}s3_secret{% endif %}
         - name: S3_URL
           value: "{{ s3_url }}"
+        - name: S3_BUCKET_PREFIX
+          value: "{{ s3_bucket_prefix }}"
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:

--- a/k8s.tpl.yml
+++ b/k8s.tpl.yml
@@ -44,6 +44,8 @@ spec:
               key: {% if use_minio %}password{% else %}s3_secret{% endif %}
         - name: S3_URL
           value: "{{ s3_url }}"
+        - name: S3_CLIENT_URL
+          value: "{{ s3_client_url }}"
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:

--- a/runner/runner/main.py
+++ b/runner/runner/main.py
@@ -12,7 +12,7 @@ import tempfile
 
 
 SQLSession = None
-s3 = None
+object_store = None
 
 
 # IP as understood by Docker daemon, not this container
@@ -145,7 +145,8 @@ def run(channel, method, properties, body):
             # Download file from S3
             logging.info("Downloading input file: %s, %s, %d bytes",
                          input_file.name, input_file.hash, input_file.size)
-            s3.Bucket('inputs').download_file(input_file.hash, local_path)
+            object_store.Bucket('inputs').download_file(input_file.hash,
+                                                        local_path)
 
             # Put file in container
             logging.info("Copying file to container")
@@ -201,7 +202,7 @@ def run(channel, method, properties, body):
 
                     # Upload file to S3
                     logging.info("Uploading file, size: %d bytes" % filesize)
-                    s3.Object('outputs', filehash).put(Body=fp)
+                    object_store.Object('outputs', filehash).put(Body=fp)
 
                 # Add OutputFile to database
                 run.output_files.append(
@@ -246,8 +247,8 @@ def main():
     tasks = TaskQueues()
 
     # Object storage
-    global s3
-    s3 = get_object_store()
+    global object_store
+    object_store = get_object_store()
 
     logging.info("Ready, listening for requests")
     tasks.consume_run_tasks(run)

--- a/runner/runner/main.py
+++ b/runner/runner/main.py
@@ -145,8 +145,7 @@ def run(channel, method, properties, body):
             # Download file from S3
             logging.info("Downloading input file: %s, %s, %d bytes",
                          input_file.name, input_file.hash, input_file.size)
-            object_store.Bucket('inputs').download_file(input_file.hash,
-                                                        local_path)
+            object_store.download_file('inputs', input_file.hash, local_path)
 
             # Put file in container
             logging.info("Copying file to container")
@@ -202,7 +201,7 @@ def run(channel, method, properties, body):
 
                     # Upload file to S3
                     logging.info("Uploading file, size: %d bytes" % filesize)
-                    object_store.Object('outputs', filehash).put(Body=fp)
+                    object_store.upload_fileobj('outputs', filehash, fp)
 
                 # Add OutputFile to database
                 run.output_files.append(

--- a/web/web/templates/results.html
+++ b/web/web/templates/results.html
@@ -29,7 +29,7 @@
 
   {% for file in run.output_files %}
 
-    <li><a href="{{ url_for('output_file', id=file.id) }}">{{ file.name }}</a>, {{ file.size }} bytes</li>
+    <li><a href="{{ output_link(file) }}">{{ file.name }}</a>, {{ file.size }} bytes</li>
 
   {% endfor %}
 

--- a/web/web/wsgi.py
+++ b/web/web/wsgi.py
@@ -5,11 +5,15 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 
-from common.utils import setup_logging
-from web.main import app  # noqa
+from common.utils import setup_logging  # noqa
 
 
 setup_logging('REPROSERVER-WEB')
+
+
+from web.main import app  # noqa
+
+
 application = app
 
 __all__ = ['application']


### PR DESCRIPTION
Used presigned requests to let the client access output files directly from S3.

* Faster, less load on compute instance
* Served from other domain, so avoid same-origin security issues

Fix #13