### PR TITLE
Add support for linking files on data repositories

### DIFF
--- a/common/common/database.py
+++ b/common/common/database.py
@@ -71,7 +71,8 @@ class Upload(Base):
                                                 ondelete='CASCADE'))
     experiment = relationship('Experiment', uselist=False,
                               back_populates='uploads')
-    submitted_ip = Column(String, nullable=False)
+    submitted_ip = Column(String, nullable=True)
+    provider_key = Column(String, nullable=True, index=True)
     timestamp = Column(DateTime, nullable=False,
                        server_default=functions.now())
 

--- a/common/common/database.py
+++ b/common/common/database.py
@@ -1,3 +1,4 @@
+from common.shortid import MultiShortIDs
 import enum
 import logging
 import os
@@ -6,8 +7,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.sql import functions
 from sqlalchemy.types import Boolean, DateTime, Enum, Integer, String
-
-from common.shortid import MultiShortIDs
 
 
 Base = declarative_base()

--- a/common/common/objectstore.py
+++ b/common/common/objectstore.py
@@ -37,6 +37,10 @@ class ObjectStore(object):
     def upload_fileobj(self, bucket, objectname, fileobj):
         self.s3.Object(self.bucket_name(bucket), objectname).put(Body=fileobj)
 
+    def upload_file(self, bucket, objectname, filename):
+        self.s3.meta.client.upload_file(filename,
+                                        self.bucket_name(bucket), objectname)
+
     def create_buckets(self):
         buckets = set(bucket.name for bucket in self.s3.buckets.all())
         missing = []

--- a/init/init.py
+++ b/init/init.py
@@ -106,8 +106,7 @@ def main():
                     logging.info("Example for %s exists", name)
                 else:
                     upload = database.Upload(experiment=experiment,
-                                             filename=name,
-                                             submitted_ip='127.0.0.1')
+                                             filename=name)
                     session.add(upload)
                     session.add(database.Example(upload=upload,
                                                  description=description))

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -3,4 +3,5 @@ enum34
 flask~=0.12
 pika~=0.10
 psycopg2~=2.7
+requests~=2.13
 SQLAlchemy~=1.1

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -155,6 +155,8 @@ def unpack(session):
         # Insert it in database
         experiment = database.Experiment(hash=filehash)
         session.add(experiment)
+
+    # Insert Upload in database
     upload = database.Upload(experiment=experiment,
                              filename=filename,
                              submitted_ip=request.remote_addr)
@@ -181,7 +183,8 @@ def reproduce_provider(provider, provider_path, session):
               .filter(database.Upload.provider_key == provider_key)
               .order_by(database.Upload.id.desc())).first()
     if not upload:
-        upload = get_experiment_from_provider(session, provider, provider_path)
+        upload = get_experiment_from_provider(session, request.remote_addr,
+                                              provider, provider_path)
     if not upload:
         return render_template('setup_notfound.html'), 404
 

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -171,7 +171,7 @@ def unpack(session):
                             upload_short_id=upload_short_id), 302)
 
 
-@app.route('/reproduce/<string:provider>/<string:provider_path>')
+@app.route('/reproduce/<string:provider>/<path:provider_path>')
 @sql_session
 def reproduce_provider(provider, provider_path, session):
     """Reproduce an experiment from a data repository (provider).

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -104,7 +104,8 @@ def context():
                                           output_file.name,
                                           mime)
 
-    return dict(output_link=output_link)
+    return dict(output_link=output_link,
+                url_for_upload=url_for_upload)
 
 
 @app.route('/')

--- a/web/web/providers.py
+++ b/web/web/providers.py
@@ -1,11 +1,112 @@
+from common import database, get_object_store
+from hashlib import sha256
+import logging
+import os
+import re
+import requests
+import tempfile
+
+
 __all__ =['get_experiment_from_provider']
 
 
-def _osf(path):
-    raise NotImplementedError  # TODO
+def get_experiment_from_provider(session, remote_addr,
+                                 provider, provider_path):
+    try:
+        getter = _PROVIDERS[provider]
+    except KeyError:
+        raise KeyError("No such provider %s" % provider)
+    return getter(session, remote_addr, provider, provider_path)
 
 
-def _figshare(path):
+def _get_from_link(session, remote_addr, provider, provider_path,
+                   link, filename, filehash=None):
+    # Check for existence of experiment
+    experiment = session.query(database.Experiment).get(filehash)
+    if experiment:
+        logging.info("Experiment with hash exists, no need to download")
+    else:
+        logging.info("Downloading %s", link)
+        fd, local_path = tempfile.mkstemp(prefix='provider_download_')
+        try:
+            # Download file & hash it
+            response = requests.get(link, stream=True)
+            response.raise_for_status()
+            hasher = sha256()
+            with open(local_path, 'wb') as f:
+                for chunk in response.iter_content(4096):
+                    f.write(chunk)
+                    hasher.update(chunk)
+
+            filehash = hasher.hexdigest()
+
+            # Check for existence of experiment
+            experiment = session.query(database.Experiment).get(filehash)
+            if experiment:
+                logging.info("File exists")
+            else:
+                # Insert it on S3
+                object_store = get_object_store()
+                object_store.upload_file('experiments', filehash,
+                                         local_path)
+                logging.info("Inserted file in storage")
+
+                # Insert it in database
+                experiment = database.Experiment(hash=filehash)
+                session.add(experiment)
+        finally:
+            os.close(fd)
+            os.remove(local_path)
+
+    # Insert Upload in database
+    upload = database.Upload(experiment=experiment,
+                             filename=filename,
+                             submitted_ip=remote_addr,
+                             provider_key='%s/%s' % (provider, provider_path))
+    session.add(upload)
+    session.commit()
+
+    return upload
+
+
+# Providers
+
+
+_osf_path = re.compile('^[a-zA-Z0-9]+$')
+
+
+def _osf(session, remote_addr, provider, path):
+    if _osf_path.match(path) is None:
+        return None
+    logging.info("Querying OSF for '%s'", path)
+    req = requests.get('https://api.osf.io/v2/files/{0}/'.format(path),
+                       headers={'Content-Type': 'application/json',
+                                'Accept': 'application/json'})
+    if req.status_code != 200:
+        logging.info("Got error %s", req.status_code)
+        return None
+    response = req.json()
+    try:
+        link = response['data']['links']['download']
+    except KeyError:
+        return None
+    except ValueError:
+        logging.error("Got invalid JSON from osf.io")
+    else:
+        try:
+            filehash = response['data']['attributes']['extra']['hashes']['sha256']
+        except KeyError:
+            filehash = None
+        try:
+            filename = response['data']['attributes']['name']
+        except KeyError:
+            filename = 'unnamed_osf_file'
+        logging.info("Got response: %s %s %s", link, filehash, filename)
+        return _get_from_link(session, remote_addr, provider, path,
+                              link, filename, filehash)
+
+
+def _figshare(session, remote_addr, provider, path):
     raise NotImplementedError  # TODO
 
 
@@ -13,11 +114,3 @@ _PROVIDERS = {
     'osf.io': _osf,
     'figshare.com': _figshare,
 }
-
-
-def get_experiment_from_provider(session, provider, provider_path):
-    try:
-        getter = _PROVIDERS[provider]
-    except KeyError:
-        return None
-    return getter(provider_path)

--- a/web/web/providers.py
+++ b/web/web/providers.py
@@ -1,0 +1,23 @@
+__all__ =['get_experiment_from_provider']
+
+
+def _osf(path):
+    raise NotImplementedError  # TODO
+
+
+def _figshare(path):
+    raise NotImplementedError  # TODO
+
+
+_PROVIDERS = {
+    'osf.io': _osf,
+    'figshare.com': _figshare,
+}
+
+
+def get_experiment_from_provider(session, provider, provider_path):
+    try:
+        getter = _PROVIDERS[provider]
+    except KeyError:
+        return None
+    return getter(provider_path)

--- a/web/web/templates/base.html
+++ b/web/web/templates/base.html
@@ -30,8 +30,8 @@
           <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-2">
             <ul class="nav navbar-nav">
               <li><a href="{{ url_for('index') }}">Unpack</a></li>
-{% if experiment_code %}
-              <li><a href="{{ url_for('reproduce', upload_short_id=experiment_code) }}">Reproduce</a></li>
+{% if experiment_url %}
+              <li><a href="{{ experiment_url }}">Reproduce</a></li>
 {% endif %}
 {% if run_id %}
               <li><a href="">View run</a></li>

--- a/web/web/templates/data.html
+++ b/web/web/templates/data.html
@@ -13,7 +13,8 @@
   {% for upload in experiment.uploads %}
 
   <p>Uploaded by {{ upload.submitted_ip }} at {{ upload.timestamp }}
-  as <a href="{{ url_for('reproduce', upload_short_id=upload.short_id) }}">{{ upload.filename }}</a></p>
+  as <a href="{{ url_for_upload(upload) }}">{{ upload.filename }}</a>
+  {% if upload.provider_key %} ({{ upload.provider_key}}){% endif %}</p>
 
   {% endfor %}
 

--- a/web/web/templates/index.html
+++ b/web/web/templates/index.html
@@ -32,7 +32,7 @@
 
   {% for example in examples %}
 
-<p><a href="{{ url_for('reproduce', upload_short_id=example.upload.short_id) }}">{{ example.upload.filename }}</a>: {{ example.description }}</p>
+<p><a href="{{ url_for_upload(example.upload) }}">{{ example.upload.filename }}</a>: {{ example.description }}</p>
 
   {% endfor %}
 

--- a/web/web/templates/results.html
+++ b/web/web/templates/results.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<h1>Package <a href="{{ url_for('reproduce', upload_short_id=experiment_code) }}">{{ run.upload.filename }}</a>, run {{ run.short_id }}</h1>
+<h1>Package <a href="{{ experiment_url }}">{{ run.upload.filename }}</a>, run {{ run.short_id }}</h1>
 
 {% if run.done %}
 

--- a/web/web/templates/setup.html
+++ b/web/web/templates/setup.html
@@ -90,7 +90,7 @@ function update_page() {
     }
     setTimeout(update_page, 3000);
   });
-  req.open("GET", "{{ url_for('reproduce', upload_short_id=upload_short_id) }}?log_from=" + log_lines);
+  req.open("GET", "{{ experiment_url }}?log_from=" + log_lines);
   req.responseType = "json";
   req.send();
 }

--- a/web/web/templates/setup.html
+++ b/web/web/templates/setup.html
@@ -35,7 +35,7 @@
 
 <h2>Run the experiment</h2>
 
-<form method="POST" action="{{ url_for('start_run', upload_short_id=experiment_code) }}" enctype="multipart/form-data">
+<form method="POST" action="{{ url_for('start_run', upload_short_id=upload_short_id) }}" enctype="multipart/form-data">
   <h3>Parameters</h3>
 
     {% if params %}
@@ -90,7 +90,7 @@ function update_page() {
     }
     setTimeout(update_page, 3000);
   });
-  req.open("GET", "{{ url_for('reproduce', upload_short_id=experiment_code) }}?log_from=" + log_lines);
+  req.open("GET", "{{ url_for('reproduce', upload_short_id=upload_short_id) }}?log_from=" + log_lines);
   req.responseType = "json";
   req.send();
 }

--- a/web/web/templates/setup_notfound.html
+++ b/web/web/templates/setup_notfound.html
@@ -4,7 +4,11 @@
 
 <h1>Package not found</h1>
 
+{% if message %}
+<p>{{ message }}</p>
+{% else %}
 <p>This package does not exist. If it existed before, it was probably removed due to inactivity.</p>
+{% endif %}
 
 <p>If you have the file, you can try <a href="{{ url_for('index') }}">uploading it again</a>.</p>
 


### PR DESCRIPTION
Fix #18

Changes Upload to have provider info or NULL, so the views can get them from that.
Adds route `/reproduce/<provider>/<path>`
Adds providers module to get files from known repositories and create Experiment & Upload.