### PR TITLE
Fix AMQP

### DIFF
--- a/common/common/tasks.py
+++ b/common/common/tasks.py
@@ -2,34 +2,61 @@ import logging
 import os
 import pika
 import pika.exceptions
+import Queue
+import threading
 import time
 
 
 class TaskQueues(object):
     def __init__(self):
-        self._connect()
+        self._connection = None
+        self._consume_queue = None
+        self._lock = threading.Lock()
+        self._callback_queue = Queue.Queue()
+        self._thread = threading.Thread(target=self._loop)
+        self._thread.start()
+
+    def _loop(self):
+        while True:
+            with self._lock:
+                try:
+                    if not self._connection:
+                        self._connect()
+                    else:
+                        self._connection.process_data_events()
+                except pika.exceptions.ConnectionClosed:
+                    logging.exception("AMQP connection is down...")
+                    self._connection = None
+            time.sleep(2)
 
     def _connect(self):
         logging.info("Connecting to AMQP broker")
-        self.connection = pika.BlockingConnection(pika.ConnectionParameters(
+        self._connection = pika.BlockingConnection(pika.ConnectionParameters(
+            heartbeat_interval=20,
             host=os.environ['AMQP_HOST'],
             credentials=pika.PlainCredentials(os.environ['AMQP_USER'],
                                               os.environ['AMQP_PASSWORD'])))
-        self.channel = self.connection.channel()
+        self.channel = self._connection.channel()
 
         self.channel.queue_declare(queue='build_queue', durable=True)
         self.channel.queue_declare(queue='run_queue', durable=True)
 
         self.channel.basic_qos(prefetch_count=1)
 
+        if self._consume_queue:
+            self.channel.basic_consume(self._callback,
+                                       queue=self._consume_queue)
+
     def _retry(self, f):
         while True:
-            try:
-                return f()
-            except pika.exceptions.ConnectionClosed:
-                logging.exception("AMQP connection is down...")
-                time.sleep(1)
-            self._connect()
+            with self._lock:
+                if self._connection is not None:
+                    try:
+                        return f()
+                    except pika.exceptions.ConnectionClosed:
+                        logging.exception("AMQP connection is down...")
+                        self._connection = None
+            time.sleep(2)
 
     def publish_build_task(self, body):
         self._retry(
@@ -43,10 +70,27 @@ class TaskQueues(object):
                                                routing_key='run_queue',
                                                body=body))
 
+    def _callback(self, channel, method, _properties, body):
+        self._callback_queue.put(body)
+        channel.basic_ack(delivery_tag=method.delivery_tag)
+
+    def _consume(self, callback, queue):
+        with self._lock:
+            self._consume_queue = queue
+            if self._connection is not None:
+                self.channel.basic_consume(self._callback, queue=queue)
+
+        while True:
+            body = self._callback_queue.get(block=True)
+            if body is None:
+                break
+            try:
+                callback(body)
+            except Exception as e:
+                logging.exception("Uncaught exception in task handler")
+
     def consume_build_tasks(self, callback):
-        self.channel.basic_consume(callback, queue='build_queue')
-        self._retry(self.channel.start_consuming)
+        self._consume(callback, 'build_queue')
 
     def consume_run_tasks(self, callback):
-        self.channel.basic_consume(callback, queue='run_queue')
-        self._retry(self.channel.start_consuming)
+        self._consume(callback, 'run_queue')


### PR DESCRIPTION
It seems that running on Google Cloud requires the heartbeats to be set. But then a timeout occurs because the build and run task take so long.

This reworks the whole AMQP stuff to use a background thread to handle the AMQP connection.

At this point one should wonder whether AMQP is the right tool for the job in the first place.