### PR TITLE
Accept a URL in the unpack view

### DIFF
--- a/web/web/main.py
+++ b/web/web/main.py
@@ -132,7 +132,7 @@ def unpack(session):
         try:
             provider, provider_path = parse_provider_url(request.form['rpz_url'])
         except ProviderError as e:
-            return render_template('setup_notfound.html',
+            return render_template('provider_notfound.html',
                                    message=e.message), 404
         else:
             return redirect(url_for('reproduce_provider',

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -129,14 +129,15 @@ def unpack(session):
     # If a URL was provided, and no file
     if request.form.get('rpz_url'):
         # Redirect to reproduce_provider view
-        provider, provider_path = parse_provider_url(request.form['rpz_url'])
         try:
-            return redirect(url_for('reproduce_provider',
-                                    provider=provider,
-                                    provider_path=provider_path))
+            provider, provider_path = parse_provider_url(request.form['rpz_url'])
         except ProviderError as e:
             return render_template('setup_notfound.html',
                                    message=e.message), 404
+        else:
+            return redirect(url_for('reproduce_provider',
+                                    provider=provider,
+                                    provider_path=provider_path))
 
     # Get uploaded file
     uploaded_file = request.files['rpz_file']

--- a/web/web/main.py
+++ b/web/web/main.py
@@ -127,7 +127,7 @@ def unpack(session):
     An experiment has been provided, store it and start the build process.
     """
     # If a URL was provided, and no file
-    if not request.files['rpz_file'].filename and request.form.get('rpz_url'):
+    if request.form.get('rpz_url'):
         # Redirect to reproduce_provider view
         provider, provider_path = parse_provider_url(request.form['rpz_url'])
         try:

--- a/web/web/providers.py
+++ b/web/web/providers.py
@@ -7,7 +7,7 @@ import requests
 import tempfile
 
 
-__all__ =['get_experiment_from_provider']
+__all__ = ['get_experiment_from_provider']
 
 
 class ProviderError(Exception):
@@ -152,3 +152,23 @@ _PROVIDERS = {
     'osf.io': _osf,
     'figshare.com': _figshare,
 }
+
+
+def parse_provider_url(url):
+    if url.startswith('http://'):
+        url = url[7:]
+    elif url.startswith('https://'):
+        url = url[8:]
+    else:
+        return None
+    if url.lower().startswith('osf.io/'):
+        path = url[7:]
+        path = path.lstrip('/')
+        path = path.split('/', 1)[0]
+        return 'osf.io', path
+    elif url.lower().startswith('figshare.com/'):
+        path = url[13:]
+        path = path.lstrip('/')
+        return 'figshare.com', path
+    else:
+        return None

--- a/web/web/providers.py
+++ b/web/web/providers.py
@@ -19,7 +19,7 @@ def get_experiment_from_provider(session, remote_addr,
     try:
         getter = _PROVIDERS[provider]
     except KeyError:
-        raise ProviderError("No such provider %s" % provider)
+        raise ProviderError("Unknown provider %s" % provider)
     return getter(session, remote_addr, provider, provider_path)
 
 
@@ -167,6 +167,7 @@ def parse_provider_url(url):
         path = path.split('/', 1)[0]
         return 'osf.io', path
     elif url.lower().startswith('figshare.com/'):
+        # TODO: Actually need to find the article ID, which is not in the URL?
         path = url[13:]
         path = path.lstrip('/')
         return 'figshare.com', path

--- a/web/web/providers.py
+++ b/web/web/providers.py
@@ -160,7 +160,7 @@ def parse_provider_url(url):
     elif url.startswith('https://'):
         url = url[8:]
     else:
-        return None
+        raise ProviderError("Invalid URL")
     if url.lower().startswith('osf.io/'):
         path = url[7:]
         path = path.lstrip('/')
@@ -171,4 +171,4 @@ def parse_provider_url(url):
         path = path.lstrip('/')
         return 'figshare.com', path
     else:
-        return None
+        raise ProviderError("Unrecognized URL")

--- a/web/web/templates/index.html
+++ b/web/web/templates/index.html
@@ -11,7 +11,7 @@
   </div>
   <div class="form-group">
     <label for="rpz_url">or provide a package's URL</label>
-    <input type="text" class="form-control" id="rpz_url" name="rpz_url" placeholder="http://experiment.rpz" disabled>
+    <input type="text" class="form-control" id="rpz_url" name="rpz_url" placeholder="http://experiment.rpz">
   </div>
   <button type="submit" class="btn btn-default">Unpack</button>
 </form>

--- a/web/web/templates/provider_notfound.html
+++ b/web/web/templates/provider_notfound.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h1>Unrecognized URL</h1>
+
+{% if message %}
+<p>{{ message }}</p>
+{% else %}
+<p>We couldn't recognize the URL you provided.</p>
+{% endif %}
+
+<p>Currently, this system recognizes the following URLs:</p>
+<ul>
+  <li>Direct links to RPZ files hosted on OSF, of the form <code>https://osf.io/&lt;5-character-ID&gt;</code> for example <code>https://osf.io/5ztp2/</code></li>
+  <!-- TODO: Put an actual RPZ on Figshare and link to it -->
+  <li>Links to RPZ files hosted on Figshare, of the form <code>https://figshare.com/&lt;path/to/article&gt;/&lt;file_id&gt;</code> for example <code>https://figshare.com/articles/Preserving_and_Reproducing_Research_with_ReproZip/4141776</code></li>
+</ul>
+
+{% endblock content %}


### PR DESCRIPTION
Accept a link from a user, parse it if it's a recognized platform, redirect to the `unpacker_provider` view.