### PR TITLE
Remove watcher

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -16,6 +16,7 @@ data:
   runner.namespace: default
   runner.pod_spec: |
     restartPolicy: Never
+    serviceAccountName: reproserver-sa
     containers:
       - name: docker
         image: docker:19.03.5-dind

--- a/k8s.yml
+++ b/k8s.yml
@@ -31,7 +31,7 @@ data:
       - name: runner
         image: reproserver_web
         imagePullPolicy: IfNotPresent
-        args: ["python3", "-c", "import sys; from reproserver.run import K8sRunner; K8sRunner._run_in_pod(sys.argv[1])"]
+        args: ["python3", "-c", "import sys; from reproserver.run import K8sRunner; K8sRunner._run_in_pod(*sys.argv[1:])"]
         env:
           - name: S3_KEY
             valueFrom:


### PR DESCRIPTION
*[Originally opened](https://gitlab.com/ViDA-NYU/reproserver/-/merge_requests/34) 2020-03-30 13:44 EDT by @remram44*

Fixes #46

Instead of having the 'web' pod watch started 'runner' pods to note their exit, update the database, and delete them, this makes the 'runner' pods do it themselves.

This means less processing in the 'web' pod and easier horizontal scaling, but is more dangerous: if something goes wrong in the 'runner' pod no one is deleting it.

Maybe there should still be a regular process in the 'web' pod going over terminated pods, noting problems, and reaping them.