### PR TITLE
Streaming upload

### DIFF
--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -7,6 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "1200"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1200"
     nginx.ingress.kubernetes.io/proxy-body-size: 4096M
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
   ingressClassName: "nginx"
   rules:

--- a/poetry.lock
+++ b/poetry.lock
@@ -636,6 +636,14 @@ pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
+name = "streaming-form-data"
+version = "1.10.2"
+description = "Streaming parser for multipart/form-data"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "tornado"
 version = "6.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -720,7 +728,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e0a74792643ed7451fc1e0be73e75a4352587e8be7b21feb9f74f614dfa89ffc"
+content-hash = "c4720f46574c20b5aae0f1886283440e8467db0af2d07a657d16f130026734b6"
 
 [metadata.files]
 aiohttp = [
@@ -1408,6 +1416,30 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.29-cp39-cp39-win32.whl", hash = "sha256:37b46bfc4af3dc226acb6fa28ecd2e1fd223433dc5e15a2bad62bf0a0cbb4e8b"},
     {file = "SQLAlchemy-1.4.29-cp39-cp39-win_amd64.whl", hash = "sha256:08cfd35eecaba79be930c9bfd2e1f0c67a7e1314355d83a378f9a512b1cf7587"},
     {file = "SQLAlchemy-1.4.29.tar.gz", hash = "sha256:fa2bad14e1474ba649cfc969c1d2ec915dd3e79677f346bbfe08e93ef9020b39"},
+]
+streaming-form-data = [
+    {file = "streaming-form-data-1.10.2.tar.gz", hash = "sha256:532c7f70697fcc8a9a37b56495dcf36df11feefe42f626cff789beac11728f45"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6d82534633c24f00e0fb3c46b90de1c21b1e97cb1403c7d002665b99ddecb5bb"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ebb2c1d31b21f0fffade29785c27bbacb8882605b9c0e51a317529ae5ad305a7"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8096fa9f229f4d32addff7a316f842f3f41ef05420a0661537802cd478613ec9"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:cec3a0a7662fb3b54236340e17d59fd70508a39b5f0d6bc000fe57fe1a3a6945"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f030f857b27392a7400b9eafe054614295057fbc4c2e5972b563e43dd1e0b8de"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-win32.whl", hash = "sha256:86aa5dabbd7d15a3dc8300d7c148b82715b6ced8b852e83ef52edab00c31777f"},
+    {file = "streaming_form_data-1.10.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3c4932a6ce2c0b518bac5e024ff1452f4ed9046ca80e79bfdfd9dff883949a60"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6b334c9c664a39d546955a125502023ae26de8e40606a456a8c59e3cdb6f5a3"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b236fcae398ade3af975da6fc519488e74fdef7d7c1c8d0b2015378de6ccd885"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:95cfa5306346a4ff0be74fb25e596ce2d068d928c5a3d35da03c08551174c932"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3c0a8a1a13e05de9c236aca6c3a3a0df13968fc7f1bda1869a8e4858ce0d4fdf"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:4b90e1020e94df2e7071899da3d8ab759e93252147f4353b929a7b731aec3135"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-win32.whl", hash = "sha256:20f619b674b5d5b1e1629b4dc60400f7dd4ed17eeebc27725664e45fe1cb68c1"},
+    {file = "streaming_form_data-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:51cd8db8c6f65b0f17a05e021269a797d266aeb455e49cac2b125598fbac1518"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f6f3adf6b334c90d0f4e3dfeddf5790f3299af7d4bed37824bfd471b17869a0c"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1bfbe6fa880fa35d73db187d5d52fda9b79c8f57944a078696714a24c3f9c3f9"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:989a8e2961c67707e04ce2d4f41daad9df8d52eebbfdeb6b3ed8ea1e431cb536"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:7ce1b8ce3bbe393d244e3ef6bde79c52cbf7a23f54e65c11a88d4bce9714db5f"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:e39645a1fcb09d7ed43960482f0d0d9747ec57c47115238347c249ec663d28fc"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-win32.whl", hash = "sha256:b31fb147fe981cee0215e1f811f99d94dfcc1bdd1a717b4d5e4896b06db454fa"},
+    {file = "streaming_form_data-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:d1fef64b966f6ff13f279131705696f4a04b29514afe288c24fb50802fe394b6"},
 ]
 tornado = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ reprozip-core = { path = "reprozip/reprozip-core", develop=true }
 reprounzip = { path = "reprozip/reprounzip", develop=true }
 reprounzip-docker = { path = "reprozip/reprounzip-docker", develop=true }
 prometheus-async = "*"
+streaming-form-data = ">=1.10,<2"
 
 [tool.poetry.dev-dependencies]
 coverage = "*"

--- a/reproserver/main.py
+++ b/reproserver/main.py
@@ -34,9 +34,7 @@ def main():
     else:
         proxy = None
     app = make_app(debug, proxy=proxy)
-    app.listen(8000, address='0.0.0.0',
-               xheaders=True,
-               max_buffer_size=1_073_741_824)
+    app.listen(8000, address='0.0.0.0', xheaders=True)
 
     loop = tornado.ioloop.IOLoop.current()
     print("\n    reproserver is now running: http://localhost:8000/\n")

--- a/reproserver/repositories/base.py
+++ b/reproserver/repositories/base.py
@@ -59,7 +59,7 @@ async def get_from_link(db, object_store, remote_addr,
             else:
                 # Insert it in database
                 # Might raise rpz_metadata.InvalidPackage
-                experiment = rpz_metadata.make_experiment(
+                experiment = await rpz_metadata.make_experiment(
                     filehash,
                     tfile.name,
                 )

--- a/reproserver/web/base.py
+++ b/reproserver/web/base.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 import importlib
 import jinja2
 import json
@@ -5,6 +6,7 @@ import logging
 import os
 import pkg_resources
 import signal
+from streaming_form_data.targets import FileTarget
 import tornado.ioloop
 import tornado.web
 
@@ -169,3 +171,17 @@ class BaseHandler(tornado.web.RequestHandler):
     def send_error_json(self, status, message, reason=None):
         self.set_status(status, reason)
         return self.send_json({'error': message})
+
+
+class HashedFileTarget(FileTarget):
+    def __init__(self, *args, hasher=None, **kwargs):
+        super(HashedFileTarget, self).__init__(*args, **kwargs)
+
+        if hasher is None:
+            self.hasher = sha256()
+        else:
+            self.hasher = hasher
+
+    def on_data_received(self, chunk):
+        super(HashedFileTarget, self).on_data_received(chunk)
+        self.hasher.update(chunk)

--- a/reproserver/web/views.py
+++ b/reproserver/web/views.py
@@ -160,7 +160,7 @@ class Upload(BaseHandler):
         else:
             # Insert it in database
             try:
-                experiment = rpz_metadata.make_experiment(
+                experiment = await rpz_metadata.make_experiment(
                     filehash,
                     self.uploaded_file.filename,
                 )

--- a/reproserver/web/views.py
+++ b/reproserver/web/views.py
@@ -1,3 +1,4 @@
+import hmac
 from datetime import datetime
 from hashlib import sha256
 import logging
@@ -5,7 +6,11 @@ import mimetypes
 import os
 import prometheus_client
 from sqlalchemy.orm import joinedload
+from streaming_form_data import StreamingFormDataParser
+from streaming_form_data.targets import ValueTarget
 import tempfile
+from tornado.escape import utf8
+from tornado.web import HTTPError, stream_request_body
 
 from .. import database
 from ..repositories import RepositoryError, RepositoryUnknown, \
@@ -13,7 +18,7 @@ from ..repositories import RepositoryError, RepositoryUnknown, \
     get_repository_page_url, parse_repository_url
 from .. import rpz_metadata
 from ..utils import PromMeasureRequest, background_future
-from .base import BaseHandler
+from .base import BaseHandler, HashedFileTarget
 
 
 logger = logging.getLogger(__name__)
@@ -45,23 +50,58 @@ class Index(BaseHandler):
         return self.finish()
 
 
+@stream_request_body
 class Upload(BaseHandler):
     """Target of the landing page.
 
     An experiment has been provided, store it and extract metadata.
     """
+    def prepare(self):
+        self.request.connection.set_max_body_size(10_000_000_000)
+        self.streaming_parser = StreamingFormDataParser(self.request.headers)
+
+        self.uploaded_file_tmp = tempfile.NamedTemporaryFile(prefix='upload_')
+        self.uploaded_file = HashedFileTarget(self.uploaded_file_tmp.name)
+        self.streaming_parser.register('rpz_file', self.uploaded_file)
+
+        self.rpz_url = ValueTarget()
+        self.streaming_parser.register('rpz_url', self.rpz_url)
+
+        self.not_permanent = ValueTarget()
+        self.streaming_parser.register('not_permanent', self.not_permanent)
+
+        self.sent_xsrf_token = ValueTarget()
+        self.streaming_parser.register('_xsrf', self.sent_xsrf_token)
+
+    def data_received(self, chunk):
+        self.streaming_parser.data_received(chunk)
+
+    def check_xsrf_cookie(self):
+        pass  # Skip built-in XSRF cookie checking, wait for body
+
+    def check_xsrf_cookie_with_body(self):
+        token = self.sent_xsrf_token.value.decode('utf-8', 'replace')
+        if not token:
+            raise HTTPError(403, "'_xsrf' argument missing from POST")
+        _, token, _ = self._decode_xsrf_token(token)
+        _, expected_token, _ = self._get_raw_xsrf_token()
+        if not token:
+            raise HTTPError(403, "'_xsrf' argument has invalid format")
+        if not hmac.compare_digest(utf8(token), utf8(expected_token)):
+            raise HTTPError(403, "XSRF cookie does not match POST argument")
+
     @PROM_REQUESTS.async_('upload')
     async def post(self):
+        self.check_xsrf_cookie_with_body()
+
         # If a URL was provided, not a file
-        rpz_url = self.get_body_argument('rpz_url', None)
+        rpz_url = self.rpz_url.value.decode('utf-8', 'replace')
         if rpz_url:
             # Redirect to reproduce_repo view
             try:
-                repo, repo_path = await parse_repository_url(
-                    self.get_body_argument('rpz_url')
-                )
+                repo, repo_path = await parse_repository_url(rpz_url)
             except RepositoryUnknown:
-                if not self.get_argument('not_permanent', None):
+                if not self.not_permanent.value:
                     return await self.render(
                         'repository_notfound.html',
                         rpz_url=rpz_url,
@@ -100,21 +140,17 @@ class Upload(BaseHandler):
             )
 
         # Get uploaded file
-        # FIXME: Don't hold the file in memory!
-        try:
-            uploaded_file = self.request.files['rpz_file'][0]
-        except (KeyError, IndexError):
+        if (
+            not os.path.getsize(self.uploaded_file.filename)
+            or not self.uploaded_file.multipart_filename
+        ):
             return await self.render(
                 'setup_badfile.html',
                 message="Missing file",
             )
-        assert uploaded_file.filename
-        logger.info("Incoming file: %r", uploaded_file.filename)
-
-        # Hash it
-        hasher = sha256(uploaded_file.body)
-        filehash = hasher.hexdigest()
-        logger.info("Computed hash: %s", filehash)
+        logger.info("Incoming file: %r", self.uploaded_file.multipart_filename)
+        filehash = self.uploaded_file.hasher.hexdigest()
+        logger.info("Computed hash: %s", self.uploaded_file.hasher.hexdigest())
 
         # Check for existence of experiment
         experiment = self.db.query(database.Experiment).get(filehash)
@@ -122,35 +158,33 @@ class Upload(BaseHandler):
             experiment.last_access = datetime.utcnow()
             logger.info("File exists in storage")
         else:
-            # Write it to disk
-            with tempfile.NamedTemporaryFile('w+b', suffix='.rpz') as tfile:
-                tfile.write(uploaded_file.body)
-
-                # Insert it in database
-                try:
-                    experiment = rpz_metadata.make_experiment(
-                        filehash,
-                        tfile.name,
-                    )
-                except rpz_metadata.InvalidPackage as e:
-                    return await self.render(
-                        'setup_badfile.html',
-                        message=str(e),
-                    )
-                self.db.add(experiment)
-
-                # Insert it on S3
-                await self.application.object_store.upload_file_async(
-                    'experiments',
+            # Insert it in database
+            try:
+                experiment = rpz_metadata.make_experiment(
                     filehash,
-                    tfile.name,
+                    self.uploaded_file.filename,
                 )
-                logger.info("Inserted file in storage")
+            except rpz_metadata.InvalidPackage as e:
+                return await self.render(
+                    'setup_badfile.html',
+                    message=str(e),
+                )
+            self.db.add(experiment)
+
+            # Insert it on S3
+            await self.application.object_store.upload_file_async(
+                'experiments',
+                filehash,
+                self.uploaded_file.filename,
+            )
+            logger.info("Inserted file in storage")
 
         # Insert Upload in database
-        upload = database.Upload(experiment=experiment,
-                                 filename=uploaded_file.filename,
-                                 submitted_ip=self.request.remote_ip)
+        upload = database.Upload(
+            experiment=experiment,
+            filename=self.uploaded_file.multipart_filename,
+            submitted_ip=self.request.remote_ip,
+        )
         self.db.add(upload)
         self.db.commit()
 


### PR DESCRIPTION
Use `streaming-form-data` to write the file upload to disk as it happens rather than holding it in memory and writing it at the end.

Doing this I noticed that by default nginx holds the whole request and feeds it to the app at once. This prevents proper handling and also causes a hiccup when Tornado reads the whole request in one go. Tornado doesn't even yield, causing this warning:

`WARNING asyncio: Executing <Task pending name='Task-5' coro=<HTTP1ServerConnection._server_request_loop() running at /usr/local/lib/python3.8/site-packages/tornado/http1connection.py:825> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7efe01ef7fa0>()] created at /usr/local/lib/python3.8/site-packages/tornado/http1connection.py:145> cb=[IOLoop.add_future.<locals>.<lambda>() at /usr/local/lib/python3.8/site-packages/tornado/ioloop.py:688] created at /usr/local/lib/python3.8/site-packages/tornado/gen.py:867> took 4.907 seconds`