### PR TITLE
Open output files in new tabs

### DIFF
--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -32,7 +32,7 @@
 
     {% for file in run.output_files %}
 
-    <li><a href="{{ output_link(file) }}">{{ file.name }}</a>, {{ file.size }} bytes</li>
+    <li><a href="{{ output_link(file) }}" target="_blank" rel="noopener">{{ file.name }}</a>, {{ file.size }} bytes</li>
 
     {% endfor %}
 


### PR DESCRIPTION
If the file is an image, it would previously show it in the current tab, which was a little awkward.

Fixes #62