### PR TITLE
Add breadcrumbs

### DIFF
--- a/reproserver/web/templates/about.html
+++ b/reproserver/web/templates/about.html
@@ -1,4 +1,4 @@
-{% set current_page = 'about' %}
+{% set current_nav = 'about' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/about.html
+++ b/reproserver/web/templates/about.html
@@ -4,6 +4,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">About</li>
+  </ol>
+</nav>
+
 <h1>About ReproServer</h1>
 
 <p>As research has become increasingly reliant on digital tools, the challenges in reproducibility have become more poignant. Releasing code and data are key to open research, but not necessarily enough for reproducibility. There are dependencies that aren't easily captured, and effect the reproducibility of research. In response to these challenges, we created ReproZip, an open source tool (see <a href="https://github.com/VIDA-NYU/reprozip">GitHub repo</a>) that bundles everything necessary to reproduce your work -- down to the operating system level!</p>

--- a/reproserver/web/templates/base.html
+++ b/reproserver/web/templates/base.html
@@ -24,13 +24,7 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarContent">
             <ul class="navbar-nav mb-2 mb-md-0 flex-md-grow-1">
-              <li class="nav-item"><a class="nav-link{% if current_page == 'index' %} active{% endif %}"{% if current_page == 'index' %} aria-current="page"{% endif %} href="{{ reverse_url('index') }}">Upload</a></li>
-{% if experiment_url %}
-              <li class="nav-item"><a class="nav-link{% if current_page == 'reproduce' %} active{% endif %}"{% if current_page == 'reproduce' %} aria-current="page"{% endif %} href="{{ experiment_url }}">Reproduce</a></li>
-{% endif %}
-{% if run_id %}
-              <li class="nav-item"><a class="nav-link{% if current_page == 'results' %} active{% endif %}"{% if current_page == 'results' %} aria-current="page"{% endif %} href="#">View run</a></li>
-{% endif %}
+              <li class="nav-item"><a class="nav-link{% if current_page == 'index' %} active{% endif %}"{% if current_page == 'index' %} aria-current="page"{% endif %} href="{{ reverse_url('index') }}">Reproduce</a></li>
               <li class="nav-item ms-md-auto"><a class="nav-link{% if current_page == 'about' %} active{% endif %}"{% if current_page == 'about' %} aria-current="page"{% endif %} href="{{ reverse_url('about') }}">About</a></li>
               <!--dropdown-->
               <li class="nav-item dropdown">

--- a/reproserver/web/templates/base.html
+++ b/reproserver/web/templates/base.html
@@ -24,7 +24,7 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarContent">
             <ul class="navbar-nav mb-2 mb-md-0 flex-md-grow-1">
-              <li class="nav-item"><a class="nav-link{% if current_nav == 'index' %} active{% endif %}"{% if current_nav == 'index' %} aria-current="page"{% endif %} href="{{ reverse_url('index') }}">Reproduce</a></li>
+              <li class="nav-item"><a class="nav-link{% if current_nav == 'reproduce' %} active{% endif %}"{% if current_nav == 'reproduce' %} aria-current="true"{% endif %} href="{{ reverse_url('index') }}">Reproduce</a></li>
               <li class="nav-item ms-md-auto"><a class="nav-link{% if current_nav == 'about' %} active{% endif %}"{% if current_nav == 'about' %} aria-current="page"{% endif %} href="{{ reverse_url('about') }}">About</a></li>
               <!--dropdown-->
               <li class="nav-item dropdown">

--- a/reproserver/web/templates/base.html
+++ b/reproserver/web/templates/base.html
@@ -24,8 +24,8 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarContent">
             <ul class="navbar-nav mb-2 mb-md-0 flex-md-grow-1">
-              <li class="nav-item"><a class="nav-link{% if current_page == 'index' %} active{% endif %}"{% if current_page == 'index' %} aria-current="page"{% endif %} href="{{ reverse_url('index') }}">Reproduce</a></li>
-              <li class="nav-item ms-md-auto"><a class="nav-link{% if current_page == 'about' %} active{% endif %}"{% if current_page == 'about' %} aria-current="page"{% endif %} href="{{ reverse_url('about') }}">About</a></li>
+              <li class="nav-item"><a class="nav-link{% if current_nav == 'index' %} active{% endif %}"{% if current_nav == 'index' %} aria-current="page"{% endif %} href="{{ reverse_url('index') }}">Reproduce</a></li>
+              <li class="nav-item ms-md-auto"><a class="nav-link{% if current_nav == 'about' %} active{% endif %}"{% if current_nav == 'about' %} aria-current="page"{% endif %} href="{{ reverse_url('about') }}">About</a></li>
               <!--dropdown-->
               <li class="nav-item dropdown">
                 <a href="#" class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false">Links<span class="caret"></span></a>

--- a/reproserver/web/templates/data.html
+++ b/reproserver/web/templates/data.html
@@ -4,6 +4,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Debug data</li>
+  </ol>
+</nav>
+
 {% for experiment in experiments %}
 
   <h1>Experiment: {{ experiment.hash }}</h1>

--- a/reproserver/web/templates/data.html
+++ b/reproserver/web/templates/data.html
@@ -1,5 +1,3 @@
-{% set current_nav = 'data' %}
-
 {% extends "base.html" %}
 
 {% block content %}

--- a/reproserver/web/templates/data.html
+++ b/reproserver/web/templates/data.html
@@ -1,4 +1,4 @@
-{% set current_page = 'data' %}
+{% set current_nav = 'data' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/index.html
+++ b/reproserver/web/templates/index.html
@@ -1,4 +1,4 @@
-{% set current_nav = 'index' %}
+{% set current_nav = 'reproduce' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/index.html
+++ b/reproserver/web/templates/index.html
@@ -1,4 +1,4 @@
-{% set current_page = 'index' %}
+{% set current_nav = 'index' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/repository_error.html
+++ b/reproserver/web/templates/repository_error.html
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Upload from URL</li>
+  </ol>
+</nav>
+
 <h1>Unrecognized URL</h1>
 
 {% if message %}

--- a/reproserver/web/templates/repository_notfound.html
+++ b/reproserver/web/templates/repository_notfound.html
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Upload from URL</li>
+  </ol>
+</nav>
+
 <h1>Unrecognized permanent URL</h1>
 
 <p>ReproServer recognizes links to some data repositories. If you provide one, you will get a permanent URL which will be back by the repository and does not depend on ReproServer's database integrity.</p>

--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -1,4 +1,4 @@
-{% set current_nav = 'results' %}
+{% set current_nav = 'reproduce' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -4,7 +4,15 @@
 
 {% block content %}
 
-<h1>Package <a href="{{ experiment_url }}">{{ run.upload.filename | truncate(60) }}</a>, run {{ run.short_id }}</h1>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{{ experiment_url }}">Package {{ run.upload.filename | truncate(60) }}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Run results</li>
+  </ol>
+</nav>
+
+<h1>Run results</h1>
 
 {% if run.done %}
 

--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -1,4 +1,4 @@
-{% set current_page = 'results' %}
+{% set current_nav = 'results' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/results_notfound.html
+++ b/reproserver/web/templates/results_notfound.html
@@ -2,6 +2,14 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item">Unknown package</li>
+    <li class="breadcrumb-item active" aria-current="page">Run results</li>
+  </ol>
+</nav>
+
 <h1>Results not found</h1>
 
 <p>Those results do not exist.</p>

--- a/reproserver/web/templates/setup.html
+++ b/reproserver/web/templates/setup.html
@@ -4,6 +4,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Package {{ filename | truncate(60) }}</li>
+  </ol>
+</nav>
+
 <h1>Package {{ filename | truncate(60) }}</h1>
 
 {% if repo_url -%}

--- a/reproserver/web/templates/setup.html
+++ b/reproserver/web/templates/setup.html
@@ -1,4 +1,4 @@
-{% set current_page = 'reproduce' %}
+{% set current_nav = 'reproduce' %}
 
 {% extends "base.html" %}
 

--- a/reproserver/web/templates/setup_badfile.html
+++ b/reproserver/web/templates/setup_badfile.html
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Upload package</li>
+  </ol>
+</nav>
+
 <h1>Error reading file</h1>
 
 {% if message %}

--- a/reproserver/web/templates/setup_notfound.html
+++ b/reproserver/web/templates/setup_notfound.html
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{{ reverse_url('index') }}">Home</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Unknown package</li>
+  </ol>
+</nav>
+
 <h1>Error getting package</h1>
 
 {% if message %}


### PR DESCRIPTION
Adds breadcrumbs at the top of pages, allowing easy navigation back (e.g. from a run to its package, from crawling or recording to the package or the web capture index)

<details><summary>Package reproduce 'setup' page</summary>

![screenshot](https://user-images.githubusercontent.com/426784/191318267-f1ce7754-6b78-4f09-845a-31649e520331.png)
</details>

<details><summary>Run results page</summary>

![screenshot](https://user-images.githubusercontent.com/426784/191318266-0d016424-8536-44b5-88c8-ca998a1fa8a8.png)
</details>

<details><summary>Web capture automated crawl 'status' page</summary>

![screenshot](https://user-images.githubusercontent.com/426784/191318269-b390b2d1-d220-4b6f-9e45-c9871f90509a.png)
</details>

Fixes #64  
Fixes #63 
Fixes #69  
Fixes #71