### PR TITLE
Make navbar full page length but center text elements

### DIFF
--- a/reproserver/web/templates/base.html
+++ b/reproserver/web/templates/base.html
@@ -13,11 +13,11 @@
   </head>
   <body>
 
-    <div class="container" id="content" role="main">
+    <div id="content" role="main">
 
       <!-- Menubar -->
       <nav class="navbar navbar-expand-md navbar-dark bg-primary">
-        <div class="container-fluid">
+        <div class="container-fluid container-md">
           <a class="navbar-brand" href="#">ReproServer</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Makes it look like this:

![image](https://user-images.githubusercontent.com/10644777/231307872-52dc7816-73eb-478c-aaca-ca112ba88216.png)
