### PR TITLE
Report progress of run

### DIFF
--- a/reproserver/database.py
+++ b/reproserver/database.py
@@ -176,6 +176,9 @@ class Run(Base):
     started = Column(DateTime, nullable=True)
     done = Column(DateTime, nullable=True)
 
+    progress_percent = Column(Integer, nullable=False, default=0)
+    progress_text = Column(Text, nullable=False, default='')
+
     submitted_ip = Column(Text, nullable=True)
 
     parameter_values = relationship('ParameterValue', back_populates='run')

--- a/reproserver/run/connector.py
+++ b/reproserver/run/connector.py
@@ -453,76 +453,40 @@ class HttpConnector(BaseConnector):
         self.http_client = AsyncHTTPClient()
         self.connection_token = connection_token
 
-    async def init_run_get_info(self, run_id):
-        response = await self.http_client.fetch(
-            '{0}/runners/run/{1}/init'.format(
+    def _post(self, run_id, method, body=None):
+        return self.http_client.fetch(
+            '{0}/runners/run/{1}/{2}'.format(
                 self.api_endpoint,
-                run_id
+                run_id,
+                method,
             ),
             method='POST',
-            body=b'{}',
+            body=b'{}' if body is None else json.dumps(body).encode('utf-8'),
             headers={
                 'Content-Type': 'application/json; charset=utf-8',
                 'X-Reproserver-Authenticate': self.connection_token,
             },
         )
+
+    async def init_run_get_info(self, run_id):
+        response = await self._post(run_id, 'init')
         return json.loads(response.body.decode('utf-8'))
 
     async def run_started(self, run_id):
-        await self.http_client.fetch(
-            '{0}/runners/run/{1}/start'.format(
-                self.api_endpoint,
-                run_id
-            ),
-            method='POST',
-            body=b'{}',
-            headers={
-                'Content-Type': 'application/json; charset=utf-8',
-                'X-Reproserver-Authenticate': self.connection_token,
-            },
-        )
+        await self._post(run_id, 'start')
 
     async def run_progress(self, run_id, percent, text):
-        await self.http_client.fetch(
-            '{0}/runners/run/{1}/set-progress'.format(
-                self.api_endpoint,
-                run_id,
-            ),
-            method='POST',
-            body=json.dumps({'percent': percent, 'text': text}),
-            headers={
-                'Content-Type': 'application/json; charset=utf-8',
-                'X-Reproserver-Authenticate': self.connection_token,
-            },
+        await self._post(
+            run_id,
+            'set-progress',
+            {'percent': percent, 'text': text},
         )
 
     async def run_done(self, run_id):
-        await self.http_client.fetch(
-            '{0}/runners/run/{1}/done'.format(
-                self.api_endpoint,
-                run_id
-            ),
-            method='POST',
-            body=b'{}',
-            headers={
-                'Content-Type': 'application/json; charset=utf-8',
-                'X-Reproserver-Authenticate': self.connection_token,
-            },
-        )
+        await self._post(run_id, 'done')
 
     async def run_failed(self, run_id, error):
-        await self.http_client.fetch(
-            '{0}/runners/run/{1}/failed'.format(
-                self.api_endpoint,
-                run_id
-            ),
-            method='POST',
-            body=json.dumps({'error': error}).encode('utf-8'),
-            headers={
-                'Content-Type': 'application/json; charset=utf-8',
-                'X-Reproserver-Authenticate': self.connection_token,
-            }
-        )
+        await self._post(run_id, 'failed', {'error': error})
 
     def get_input_links(self, run_info):
         # The input links are already set by init_run_get_info()
@@ -627,7 +591,7 @@ class HttpConnector(BaseConnector):
                     }
                     for line in lines
                 ],
-            }),
+            }).encode('utf-8'),
             headers={
                 'Content-Type': 'application/json; charset=utf-8',
                 'X-Reproserver-Authenticate': self.connection_token,

--- a/reproserver/run/docker.py
+++ b/reproserver/run/docker.py
@@ -100,6 +100,11 @@ class DockerRunner(BaseRunner):
                     ", ".join(extra_config['required']),
                 ))
 
+        await self.connector.run_progress(
+            run_info['id'],
+            40, "Setting up container",
+        )
+
         # Make build directory
         directory = tempfile.mkdtemp('build_%s' % run_info['experiment_hash'])
 
@@ -151,7 +156,13 @@ class DockerRunner(BaseRunner):
 
             # Update status in database
             logger.info("Starting container")
-            await self.connector.run_started(run_info['id'])
+            await asyncio.gather(
+                self.connector.run_started(run_info['id']),
+                self.connector.run_progress(
+                    run_info['id'],
+                    80, "Container is running",
+                ),
+            )
 
             # Start container and wait until completion
             try:

--- a/reproserver/run/docker.py
+++ b/reproserver/run/docker.py
@@ -50,6 +50,12 @@ class DockerRunner(BaseRunner):
             logger.info("Pulled image from cache")
         else:
             logger.info("Couldn't get image from cache, building")
+            await self.connector.run_progress(
+                run_info['id'],
+                60,
+                "No cached container for this RPZ, building; "
+                + "this might take several minutes",
+            )
             with tempfile.TemporaryDirectory() as directory:
                 # Get experiment file
                 logger.info("Downloading file...")

--- a/reproserver/run/k8s.py
+++ b/reproserver/run/k8s.py
@@ -124,6 +124,8 @@ class K8sRunner(BaseRunner):
         if extra_containers:
             pod_spec['containers'].extend(extra_containers)
 
+        await self.connector.run_progress(run_id, 20, "Worker starting")
+
         async with k8s_client.ApiClient() as api:
             # Create a Kubernetes pod to run
             v1 = k8s_client.CoreV1Api(api)

--- a/reproserver/web/__init__.py
+++ b/reproserver/web/__init__.py
@@ -55,6 +55,7 @@ def make_app(debug=False, xsrf_cookies=True, proxy=None):
             URLSpec('/health', views.Health, name='health'),
             URLSpec('/runners/run/([^/]+)/init', api.InitRunGetInfo),
             URLSpec('/runners/run/([^/]+)/start', api.RunStarted),
+            URLSpec('/runners/run/([^/]+)/set-progress', api.RunSetProgress),
             URLSpec('/runners/run/([^/]+)/done', api.RunDone),
             URLSpec('/runners/run/([^/]+)/failed', api.RunFailed),
             URLSpec('/runners/run/([^/]+)/output/(.+)', api.UploadOutput),

--- a/reproserver/web/api.py
+++ b/reproserver/web/api.py
@@ -61,6 +61,31 @@ class RunStarted(BaseApiHandler):
         await self.connector.run_started(run_id)
 
 
+class RunSetProgress(BaseApiHandler):
+    async def post(self, run_id):
+        try:
+            run_id = int(run_id)
+        except (ValueError, OverflowError):
+            return await self.send_error_json(400, "Invalid run ID")
+
+        body = self.get_json()
+        try:
+            percent = body['percent']
+            text = body['text']
+            if (
+                not isinstance(percent, int)
+                or not isinstance(text, str)
+            ):
+                raise KeyError
+        except KeyError:
+            return await self.send_error_json(
+                400,
+                "Expected JSON object with 'percent' and 'text' keys",
+            )
+
+        await self.connector.run_progress(run_id, percent, text)
+
+
 class RunDone(BaseApiHandler):
     async def post(self, run_id):
         try:

--- a/reproserver/web/api.py
+++ b/reproserver/web/api.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+import functools
 import hashlib
 import logging
 import tempfile
@@ -33,13 +34,21 @@ class BaseApiHandler(BaseHandler):
         )
 
 
-class InitRunGetInfo(BaseApiHandler):
-    async def post(self, run_id):
+def parse_run_id(wrapped):
+    @functools.wraps(wrapped)
+    def wrapper(self, run_id, *args):
         try:
             run_id = int(run_id)
         except (ValueError, OverflowError):
-            return await self.send_error_json(400, "Invalid run ID")
+            return self.send_error_json(400, "Invalid run ID")
+        return wrapped(self, run_id, *args)
 
+    return wrapper
+
+
+class InitRunGetInfo(BaseApiHandler):
+    @parse_run_id
+    async def post(self, run_id):
         run_info = await self.connector.init_run_get_info(run_id)
 
         # Get signed download link for bundle
@@ -52,22 +61,14 @@ class InitRunGetInfo(BaseApiHandler):
 
 
 class RunStarted(BaseApiHandler):
+    @parse_run_id
     async def post(self, run_id):
-        try:
-            run_id = int(run_id)
-        except (ValueError, OverflowError):
-            return await self.send_error_json(400, "Invalid run ID")
-
         await self.connector.run_started(run_id)
 
 
 class RunSetProgress(BaseApiHandler):
+    @parse_run_id
     async def post(self, run_id):
-        try:
-            run_id = int(run_id)
-        except (ValueError, OverflowError):
-            return await self.send_error_json(400, "Invalid run ID")
-
         body = self.get_json()
         try:
             percent = body['percent']
@@ -87,22 +88,14 @@ class RunSetProgress(BaseApiHandler):
 
 
 class RunDone(BaseApiHandler):
+    @parse_run_id
     async def post(self, run_id):
-        try:
-            run_id = int(run_id)
-        except (ValueError, OverflowError):
-            return await self.send_error_json(400, "Invalid run ID")
-
         await self.connector.run_done(run_id)
 
 
 class RunFailed(BaseApiHandler):
+    @parse_run_id
     async def post(self, run_id):
-        try:
-            run_id = int(run_id)
-        except (ValueError, OverflowError):
-            return await self.send_error_json(400, "Invalid run ID")
-
         body = self.get_json()
         try:
             error = body['error']
@@ -132,12 +125,8 @@ class UploadOutput(BaseApiHandler):
         self.temp_file.write(chunk)
         self.hasher.update(chunk)
 
+    @parse_run_id
     def put(self, run_id, output_name):
-        try:
-            run_id = int(run_id)
-        except (ValueError, OverflowError):
-            return self.send_error_json(400, "Invalid run ID")
-
         self.temp_file.flush()
 
         return asyncio.get_event_loop().run_in_executor(
@@ -152,6 +141,7 @@ class UploadOutput(BaseApiHandler):
 
 
 class Log(BaseApiHandler):
+    @parse_run_id
     def post(self, run_id):
         obj = self.get_json()
         for line in obj['lines']:

--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -54,7 +54,13 @@
 
 {% else %}
 
-<p>Run in progress, please wait...</p>
+<div id="loading">
+  <div id="progress" class="progress mb-3">
+    <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
+  </div>
+  <p id="progress-text"></p>
+  <p id="web-loading-text"></p>
+</div>
 
 {% if run.ports %}
 <p>
@@ -81,13 +87,19 @@ function update_page() {
   var req = new XMLHttpRequest();
   req.addEventListener("load", function(e) {
     if(this.status == 200) {
-      if(this.response.done) {
+      var status = this.response;
+      if(status.done) {
         window.location.reload();
-      } else if(this.response.log.length > 0) {
-        log_lines += this.response.log.length;
-        var dom_log = document.getElementById("log");
-        dom_log.textContent += this.response.log.join("\n") + "\n";
+        return;
       }
+      if(status.log.length > 0) {
+        log_lines += status.log.length;
+        var dom_log = document.getElementById("log");
+        dom_log.textContent += status.log.join("\n") + "\n";
+      }
+      document.getElementById('progress-text').innerText = status.progress_text;
+      document.getElementById('progress-bar').setAttribute('aria-valuenow', status.progress_percent);
+      document.getElementById('progress-bar').style.width = status.progress_percent + '%';
     }
     setTimeout(update_page, 3000);
   });
@@ -97,13 +109,12 @@ function update_page() {
   req.send();
 }
 
-setTimeout(update_page, 3000);
+window.addEventListener('load', update_page);
 </script>
 
 {% endif %}
 
 {% if wacz and run.ports | length %}
-<p id="web-loading"></p>
 
 <script type="x-template" id="web">
 <replay-web-page
@@ -125,16 +136,14 @@ var web_status = "starting";
 
 function web_update_status() {
   if(web_status == "ready") {
-    document.getElementById("web-loading").style.display = "none";
+    document.getElementById("loading").style.display = "none";
     var web = document.getElementById("web");
     var web_widget = document.createElement("div");
     web_widget.setAttribute("id", "web");
     web_widget.innerHTML = web.innerHTML;
     web.parentNode.replaceChild(web_widget, web);
-  } else if(web_status == "starting") {
-    document.getElementById("web-loading").innerText = "The package is starting up and is not yet ready to serve web requests. Please wait...";
   } else if(web_status == "toolong") {
-    document.getElementById("web-loading").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
+    document.getElementById("web-loading-text").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
   }
 }
 

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -34,6 +34,9 @@ function update_page() {
         var dom_log = document.getElementById("log");
         dom_log.textContent += this.response.log.join("\n") + "\n";
       }
+      document.getElementById('progress-text').innerText = this.response.progress_text;
+      document.getElementById('progress-bar').setAttribute('aria-valuenow', this.response.progress_percent);
+      document.getElementById('progress-bar').style.width = this.response.progress_percent + '%';
       if(this.response.done) {
         return;
       }
@@ -46,7 +49,7 @@ function update_page() {
   req.send();
 }
 
-setTimeout(update_page, 3000);
+window.addEventListener('load', update_page);
 
 async function doUpload() {
   const recorder = document.querySelector("record-web-page");
@@ -79,7 +82,13 @@ async function doUpload() {
 
 </script>
 
-<p id="web-loading"></p>
+<div id="web-loading">
+  <p id="web-loading-text"></p>
+  <div id="progress" class="progress mb-3">
+    <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
+  </div>
+  <p id="progress-text"></p>
+</div>
 
 <script type="x-template" id="web">
 <button class="btn btn-primary" onclick="doUpload()">End recording and save WACZ</button>
@@ -107,9 +116,9 @@ function web_update_status() {
     web_widget.innerHTML = web.innerHTML;
     web.parentNode.replaceChild(web_widget, web);
   } else if(web_status == "starting") {
-    document.getElementById("web-loading").innerText = "The package is starting up and is not yet ready to serve web requests. Please wait...";
+    document.getElementById("web-loading-text").innerText = "The package is starting up and is not yet ready to serve web requests. Please wait...";
   } else if(web_status == "toolong") {
-    document.getElementById("web-loading").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
+    document.getElementById("web-loading-text").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
   }
 }
 

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -30,16 +30,17 @@ function update_page() {
   var req = new XMLHttpRequest();
   req.addEventListener("load", function(e) {
     if(this.status == 200) {
-      last_status = this.response;
-      if(last_status.log.length > 0) {
-        log_lines += last_status.log.length;
+      var status = this.response;
+      last_status = status;
+      if(status.log.length > 0) {
+        log_lines += status.log.length;
         var dom_log = document.getElementById("log");
-        dom_log.textContent += last_status.log.join("\n") + "\n";
+        dom_log.textContent += status.log.join("\n") + "\n";
       }
-      document.getElementById('progress-text').innerText = last_status.progress_text;
-      document.getElementById('progress-bar').setAttribute('aria-valuenow', last_status.progress_percent);
-      document.getElementById('progress-bar').style.width = last_status.progress_percent + '%';
-      if(last_status.done) {
+      document.getElementById('progress-text').innerText = status.progress_text;
+      document.getElementById('progress-bar').setAttribute('aria-valuenow', status.progress_percent);
+      document.getElementById('progress-bar').style.width = status.progress_percent + '%';
+      if(status.done) {
         return;
       }
     }

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -85,11 +85,11 @@ async function doUpload() {
 </script>
 
 <div id="web-loading">
-  <p id="web-loading-text"></p>
   <div id="progress" class="progress mb-3">
     <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
   </div>
   <p id="progress-text"></p>
+  <p id="web-loading-text"></p>
 </div>
 
 <script type="x-template" id="web">
@@ -118,8 +118,6 @@ function web_update_status() {
     web_widget.setAttribute("id", "web");
     web_widget.innerHTML = web.innerHTML;
     web.parentNode.replaceChild(web_widget, web);
-  } else if(web_status == "starting") {
-    document.getElementById("web-loading-text").innerText = "The package is starting up and is not yet ready to serve web requests. Please wait...";
   } else if(web_status == "toolong") {
     document.getElementById("web-loading-text").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
   }

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -120,7 +120,7 @@ function web_update_status() {
     web_widget.innerHTML = web.innerHTML;
     web.parentNode.replaceChild(web_widget, web);
   } else if(web_status == "toolong") {
-    document.getElementById("web-loading-text").innerHTML = "The package is not ready to serve web requests after 30 seconds.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
+    document.getElementById("web-loading-text").innerHTML = "THIS IS TAKING LONGER THAN EXPECTED. HANG TIGHT? The package is not ready to serve web requests after 2 minutes.<br>Please check the logs above to see if something went wrong with startup, and if you have the right port number (you entered {{ run.ports[0].port_number }} into ReproServer).";
   }
 }
 

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -25,19 +25,21 @@
 
 <script>
 var log_lines = {{ log | length }};
+var last_status = undefined;
 function update_page() {
   var req = new XMLHttpRequest();
   req.addEventListener("load", function(e) {
     if(this.status == 200) {
-      if(this.response.log.length > 0) {
-        log_lines += this.response.log.length;
+      last_status = this.response;
+      if(last_status.log.length > 0) {
+        log_lines += last_status.log.length;
         var dom_log = document.getElementById("log");
-        dom_log.textContent += this.response.log.join("\n") + "\n";
+        dom_log.textContent += last_status.log.join("\n") + "\n";
       }
-      document.getElementById('progress-text').innerText = this.response.progress_text;
-      document.getElementById('progress-bar').setAttribute('aria-valuenow', this.response.progress_percent);
-      document.getElementById('progress-bar').style.width = this.response.progress_percent + '%';
-      if(this.response.done) {
+      document.getElementById('progress-text').innerText = last_status.progress_text;
+      document.getElementById('progress-bar').setAttribute('aria-valuenow', last_status.progress_percent);
+      document.getElementById('progress-bar').style.width = last_status.progress_percent + '%';
+      if(last_status.done) {
         return;
       }
     }
@@ -106,6 +108,7 @@ async function doUpload() {
 
 <script>
 var web_status = "starting";
+var web_timer = undefined;
 
 function web_update_status() {
   if(web_status == "ready") {
@@ -123,6 +126,16 @@ function web_update_status() {
 }
 
 function web_check() {
+  if(!last_status || !last_status.started) {
+    setTimeout(web_check, 2000);
+    return;
+  }
+
+  if(!web_timer) {
+    console.log("Starting 30s timer");
+    web_timer = setTimeout(function() { web_status = "toolong"; web_update_status(); }, 30000);
+  }
+
   var req = new XMLHttpRequest();
   req.addEventListener("load", function(e) {
     if(this.status != 503) {
@@ -137,7 +150,5 @@ function web_check() {
   req.send();
 }
 web_check();
-
-setTimeout(function() { web_status = "toolong"; web_update_status(); }, 30000);
 </script>
 {% endblock content %}

--- a/reproserver/web/views.py
+++ b/reproserver/web/views.py
@@ -561,11 +561,26 @@ class ResultsJson(BaseHandler):
         if run is None:
             return self.send_error_json(404, "Not found")
 
+        progress_percent = run.progress_percent
+        progress_text = run.progress_text
+        if run.done:
+            progress_percent = 100
+            progress_text = "Completed"
+        elif not progress_text:
+            if not run.started:
+                progress_percent = 0
+                progress_text = "Queued"
+            else:
+                progress_percent = 40
+                progress_text = "Starting"
+
         log_from = int(self.get_query_argument('log_from', '0'), 10)
         return self.send_json({
             'started': bool(run.started),
             'done': bool(run.done),
             'log': run.get_log(log_from),
+            'progress_percent': progress_percent,
+            'progress_text': progress_text,
         })
 
 


### PR DESCRIPTION
It can take a little while for the experiment to start running. With a multi-gigabyte RPZ, it can actually take a couple of minutes.

This adds a progress bar and a message to the run results page, keeping the user informed. This also integrates with the HTTP status check, which we now only start once the container has started, showing the warning after 30s have elapsed from that point.

The progress bar doesn't actually reflect the overall time, as the relative length of each stage will vary, but should hopefully give an idea of progress.

* 20% Worker starting
* 40% Setting up container
* 60% No cached container for this RPZ, building; this might take several minutes
* 80% Container is running
    * If 30s pass without getting a response on the HTTP port, show the warning

<details><summary>Screenshots</summary>

![screenshot: worker starting](https://github.com/VIDA-NYU/reproserver/assets/426784/1f2f3253-67ae-4c34-b944-874dbf60b3ec)

![screenshot: setting up container](https://github.com/VIDA-NYU/reproserver/assets/426784/55ab382a-5a0e-4cf9-b186-c19552cd3293)

![screenshot: container is running](https://github.com/VIDA-NYU/reproserver/assets/426784/6b94fbf1-889c-4e15-937d-b36b3b2ae102)

![screenshot: 30s warning](https://github.com/VIDA-NYU/reproserver/assets/426784/ed48f8f3-de8d-4494-b0c7-d672448b3014)

![screenshot: site available](https://github.com/VIDA-NYU/reproserver/assets/426784/ea297dac-4b5e-490d-8925-290b53c5bca5)

</details>

Fixes #49

Closes #52