### PR TITLE
Update replay/recordwebpage, use separate versions of replaywebpage for recording and replay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@ k8s
 # Downloaded from get_assets.sh
 reproserver/web/static/js/archivewebpage-ui.js
 reproserver/web/static/replay/sw.js
+reproserver/web/static/js/replaywebpage-ui.js
+reproserver/web/static/replay/rwp-sw.js
 
 reprozip/.travis
 reprozip/docs

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # Downloaded from get_assets.sh
 reproserver/web/static/js/archivewebpage-ui.js
 reproserver/web/static/replay/sw.js
+reproserver/web/static/js/replaywebpage-ui.js
+reproserver/web/static/replay/rwp-sw.js
 
 # Python
 __pycache__

--- a/reproserver/web/templates/base.html
+++ b/reproserver/web/templates/base.html
@@ -8,7 +8,8 @@
 
     <link rel="stylesheet" href="{{ static_url('css/bootstrap.min.css') }}">
     <link rel="stylesheet" href="{{ static_url('css/custom.css') }}">
-    <script async src="{{ static_url('js/archivewebpage-ui.js') }}"></script>
+    {% block head_insert %}
+    {% endblock %}
     <title>{{ page_title }}</title>
     <meta name="description" content="Reproduce ReproZip packages in the cloud">
   </head>

--- a/reproserver/web/templates/results.html
+++ b/reproserver/web/templates/results.html
@@ -2,6 +2,10 @@
 
 {% extends "base.html" %}
 
+{% block head_insert %}
+<script async src="{{ static_url('js/replaywebpage-ui.js') }}"></script>
+{% endblock %}
+
 {% block content %}
 
 <nav aria-label="breadcrumb">
@@ -124,6 +128,7 @@ window.addEventListener('load', update_page);
   style="height: 500px; display: flex; border: 1px solid black;"
   url="http://{{ web_hostname }}/"
   replayBase="/static/replay/"
+  swName="rwp-sw.js"
   source="{{ wacz }}"
   coll="{{ web_coll }}"
   noWebWorker

--- a/reproserver/web/templates/webcapture/record.html
+++ b/reproserver/web/templates/webcapture/record.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block head_insert %}
+<script async src="{{ static_url('js/archivewebpage-ui.js') }}"></script>
+{% endblock %}
+
 {% block content %}
 
 <nav aria-label="breadcrumb">

--- a/scripts/get_assets.sh
+++ b/scripts/get_assets.sh
@@ -33,5 +33,5 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.9.8/dist/embed/ui.js" "reproserver/web/static/js/archivewebpage-ui.js" "30e28e10b1afcf7587405a03aa9bcff1abc827aa5351d51ffdb555d5440e0945"
-download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.9.8/dist/embed/replay/sw.js" "reproserver/web/static/replay/sw.js" "32e0fe19718935f93a2599ed9a2f5daed52cb6237e388841f4f56e2453c7f728"
+download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.11.0/dist/embed/ui.js" "reproserver/web/static/js/archivewebpage-ui.js" "9b1a7edad4ed7f07daf96c3b32a8db8ea08aa155fda87c2ba089d36dc51758a2"
+download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.11.0/dist/embed/replay/sw.js" "reproserver/web/static/replay/sw.js" "bb742cc4cec2e373e9dee9de018f567cd5c10dd3e4a9a9d807841cd9b2e090f2"

--- a/scripts/get_assets.sh
+++ b/scripts/get_assets.sh
@@ -35,3 +35,5 @@ cd "$(dirname "$0")/.."
 
 download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.11.0/dist/embed/ui.js" "reproserver/web/static/js/archivewebpage-ui.js" "9b1a7edad4ed7f07daf96c3b32a8db8ea08aa155fda87c2ba089d36dc51758a2"
 download_asset "https://cdn.jsdelivr.net/npm/@webrecorder/archivewebpage@0.11.0/dist/embed/replay/sw.js" "reproserver/web/static/replay/sw.js" "bb742cc4cec2e373e9dee9de018f567cd5c10dd3e4a9a9d807841cd9b2e090f2"
+download_asset "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.6/ui.js" "reproserver/web/static/js/replaywebpage-ui.js" "5644cd2a76b4c9ef0dd73067ba5c509e8246e328f56ef9ff8d8616caeb2f407a"
+download_asset "https://cdn.jsdelivr.net/npm/replaywebpage@1.8.6/sw.js" "reproserver/web/static/replay/rwp-sw.js" "89af3d81c6e3a6c5d650a9fdcb412c416727dc2d954332e24d462cf0269b8952"


### PR DESCRIPTION
…laywebpage for replay, instead of relying on

bundled replaywebpage pinned in archivewebpage:
- add separate replaywebpage ui and sw.js from https://cdn.jsdelivr.net/npm/replaywebpage@1.8.6/{ui.js,sw.js} as js/replaywebpage-ui.js and replay/rwp-sw.js
- parametrize using archiveweb.page or replayweb.page script via new head_insert block, set to appropriate file in record.html and results.html